### PR TITLE
Run e2e tests during circleci build of api

### DIFF
--- a/app/controllers/test.js
+++ b/app/controllers/test.js
@@ -13,14 +13,27 @@ module.exports = function(app) {
   var resetTestDatabase = function(req, res, next) {
 
     // Check to make sure this is the test_server
-    if (config.env !== 'test_server' && config.env !== 'circleci_test_server') {
+    if (config.env !== 'development' &&
+        config.env !== 'circleci' &&
+        // TODO remove these 2 when circleci client e2e tests run api locally
+        config.env !== 'test_server' &&
+        config.env !== 'circleci_test_server') {
       return next(new errors.BadRequest('Must only be run on test server'));
     }
 
-    // Hard code to avoid resetting the production db by mistake
-    const databaseName = config.env === 'test_server'
-      ? 'opencollective_test'
-      : 'dd7n9gp6tr4u36';
+    // Hard code database name to avoid resetting the production db by mistake
+    var databaseName;
+    switch(config.env) {
+      case 'circleci':
+        databaseName = 'circle_test';
+        break;
+      case 'development':
+        databaseName = 'opencollective_e2e';
+        break;
+      default:
+        databaseName = 'dd7n9gp6tr4u36';
+        break;
+    }
 
     const sequelize = new Sequelize(
       databaseName,

--- a/circle.yml
+++ b/circle.yml
@@ -8,13 +8,23 @@ machine:
   post:
     - npm install jscs@1.13.1 -g
     - npm install mocha@2.4.5 -g
+    - cd api && npm run test:e2e website install
+#    - cd api && npm run test:e2e app install
   node:
     version: 5.1.0
   services:
     - postgresql
+dependencies:
+  cache_directories:
+    - "~/cache"
+  pre:
+    - npm run install:debs
 test:
   override:
     - npm run circleci
+  post:
+    - npm run test:e2e website run
+#    - npm run test:e2e app run
 deployment:
   staging:
     branch: staging

--- a/index.js
+++ b/index.js
@@ -44,15 +44,13 @@ app.set('controllers', require('./app/controllers')(app));
 
 require('./app/routes')(app);
 
-if (app.set('env') !== 'test' && app.set('env') !== 'circleci') {
-  /**
-   * Start server
-   */
- const port = process.env.PORT || 3060;
-  const server = app.listen(port, () => {
-    const host = require('os').hostname();
-    console.log('OpenCollective API listening at http://%s:%s in %s environment.', host, server.address().port, app.set('env'));
-  });
-}
+/**
+ * Start server
+ */
+const port = process.env.PORT || 3060;
+const server = app.listen(port, () => {
+  const host = require('os').hostname();
+  console.log('OpenCollective API listening at http://%s:%s in %s environment.', host, server.address().port, app.set('env'));
+});
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "circleci": "NODE_ENV=circleci npm run hint && mocha --reporter mocha-circleci-reporter --reporter-options mochaFile=$CIRCLE_TEST_REPORTS/junit/junit.xml test",
     "start": "npm run hint && node .",
     "dev": "nodemon -e js,hbs -w app",
-    "hint": "eslint '**/*.js' --quiet",
+    "hint": "eslint 'app/**/*.js' --quiet",
     "db:migrate": "sequelize db:migrate --config config/sequelize_cli.json --models-path app/models/ --env  $SEQUELIZE_ENV",
     "db:migrate:undo": "sequelize db:migrate:undo --config config/sequelize_cli.json --models-path app/models/ --env  $SEQUELIZE_ENV",
     "db:migrate:dev": "sequelize db:migrate --models-path app/models/ --env development --url postgres://localhost:5432/${PG_DATABASE:='opencollective_localhost'}",
@@ -88,7 +88,9 @@
     "deploy:production": "bash -x scripts/deploy.sh production",
     "report:tx": "node scripts/report_transactions",
     "check:transactions": "node scripts/check_transactions_on_stripe",
-    "script": "node scripts/execute"
+    "script": "node scripts/execute",
+    "install:debs": "bash -x scripts/install_apt_get_debs.sh",
+    "test:e2e": "sh scripts/test_e2e.sh"
   },
   "license": "Copyright (c) 2016 OpenCollective, Inc."
 }

--- a/scripts/install_apt_get_debs.sh
+++ b/scripts/install_apt_get_debs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# cfr. https://discuss.circleci.com/t/add-ability-to-cache-apt-get-programs/598/6
+
+set -e
+
+APT_PACKAGES=(google-chrome-stable)
+APT_CACHE=~/cache/apt
+
+# Work from the directory CI will cache
+mkdir -p ${APT_CACHE}
+cd ${APT_CACHE}
+
+# check we have a deb for each package
+useCache=true
+for pkg in "${APT_PACKAGES[@]}"; do
+  if ! ls | grep "^${pkg}"; then
+    useCache=false
+  fi
+done
+
+set -x
+
+if [ ${useCache} == true ]; then
+  sudo dpkg -i *.deb
+  exit 0
+fi
+
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+sudo apt-get update
+sudo apt-get install --reinstall "${APT_PACKAGES[@]}"
+
+cp -v /var/cache/apt/archives/*.deb ${APT_CACHE}

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# exit script if any error occurs
+set -e
+
+usage() {
+  echo "Usage: $0 <repo> [<phase>]"
+  echo " "
+  echo "  <repo>:  api, website or app"
+  echo "  <phase>: install or run. Executes both if none specified."
+  echo " "
+  echo "E.g : $0 website install"
+  echo "      $0 website run"
+  echo " "
+  echo " -or- $0 website"
+  echo " "
+  exit $1;
+}
+
+# Parsing script parameters
+API_DIR=$PWD
+CLIENT=$1
+if [ "$CLIENT" != "website" ] && [ "$CLIENT" != "app" ]; then
+  usage 1;
+fi
+PHASES=$2
+if [ "$PHASES" != "" ]; then
+  if [ "$PHASES" != "install" ] && [ "$PHASES" != "run" ]; then
+    usage 1;
+  fi
+else
+  PHASES="install run"
+fi
+
+setClientDir() {
+  DIR_VAR_NAME=$(echo ${CLIENT} | awk '{print toupper($0)}')_DIR
+  if [ -f ".env" ] && [ -d "${!DIR_VAR_NAME}" ]; then
+    echo ${!DIR_VAR_NAME}
+  else
+    echo "$API_DIR/$CLIENT-checkout"
+  fi
+}
+
+# setting variables
+[ -f "${API_DIR}/.env" ] && source ${API_DIR}/.env
+CLIENT_DIR=$(setClientDir)
+
+if [ "$NODE_ENV" = "development" ]; then
+  ARTIFACTS_DIR="${API_DIR}/test/e2e/output"
+  # don't override developer's database
+  echo "setting PG_DATABASE=opencollective_e2e"
+  export PG_DATABASE=opencollective_e2e
+else
+  ARTIFACTS_DIR="${CIRCLE_ARTIFACTS}/e2e"
+fi
+mkdir -p ${ARTIFACTS_DIR}
+
+finish() {
+  EXIT_CODE=$?
+  if [ ! ${EXIT_CODE} ]; then
+    trap '' ERR
+    #pkill -f node selenium chromedriver Chrome
+    # for some reason the node processes spawned by npm aren't killed upon exit, but others seem to be
+    pkill -f node
+  fi
+  echo "Finished $0 $CLIENT $PHASE with exit code ${EXIT_CODE}."
+  exit ${EXIT_CODE}
+}
+
+# cleanup upon exit
+trap finish EXIT TERM
+
+installClient() {
+  if [ -d ${CLIENT_DIR} ]; then
+    echo "$CLIENT already checked out to $CLIENT_DIR"
+  else
+    echo "Checking out $CLIENT into ${CLIENT_DIR}"
+    # use Github SVN export to avoid fetching git history, faster
+    REMOTE_SVN=https://github.com/OpenCollective/${CLIENT}/trunk
+    svn export $REMOTE_SVN ${CLIENT_DIR}
+  fi
+  cd ${CLIENT_DIR}
+  echo "Performing NPM install"
+  START=$(date +%s)
+  npm install
+  END=$(date +%s)
+  echo "Finished executing NPM install in $(($END - $START)) seconds"
+}
+
+linkClientNmToCache() {
+  CLIENT_NM="${CLIENT_DIR}/node_modules/"
+  CLIENT_NM_CACHE="${HOME}/cache/${CLIENT}_node_modules"
+  echo "Linking ${CLIENT_NM_CACHE} -> ${CLIENT_NM}"
+  ln -s ${CLIENT_NM_CACHE} ${CLIENT_NM}
+}
+
+runProcess() {
+  NAME=$1
+  cd $2
+  COMMAND=$3
+  LOG_FILE="$ARTIFACTS_DIR/$NAME.log"
+  PARENT=$$
+  echo "Starting $NAME and saving output to $LOG_FILE"
+  # in case spawned process exits unexpectedly, kill parent process and its sub-processes (via the trap)
+  sh -c "$COMMAND | tee $LOG_FILE 2>&1;
+         kill $PARENT 2>/dev/null" &
+  sleep 20
+}
+
+runApi() {
+  runProcess api ${API_DIR} 'npm start'
+}
+
+runClient() {
+  if [ ! -d ${CLIENT_DIR} ]; then
+    echo "${CLIENT} not installed in ${CLIENT_DIR}, exiting."
+    exit 1;
+  else
+    runProcess ${CLIENT} ${CLIENT_DIR} 'npm start'
+  fi
+}
+
+testE2E() {
+  echo "Starting ${CLIENT} E2E tests"
+  cd ${CLIENT_DIR}
+  npm run nightwatch
+  echo "Finished ${CLIENT} E2E tests"
+}
+
+for PHASE in ${PHASES}; do
+  if [ "$PHASE" = "install" ]; then
+    installClient;
+    linkClientNmToCache;
+  elif [ "$PHASE" = "run" ]; then
+    runApi;
+    runClient;
+    testE2E;
+  fi
+done


### PR DESCRIPTION
This branch enables e2e tests to be executed fully locally from the api repo on circleci. Additionally, it enables developers to do the same locally. Also, if `WEBSITE_DIR` and `APP_DIR` are added to their `.env`, the script will reuse these checkouts instead of performing a fresh one. 

I also attempted to cache the website and app node_module subdirectories but for some reason it's refused by circleci cfr. "Save cache" phase:

````
  ✗ /home/ubuntu/api/.app_node_modules
  ✗ /home/ubuntu/api/.website_node_modules
````