### PR TITLE
Show accurate balance

### DIFF
--- a/app/controllers/groups.js
+++ b/app/controllers/groups.js
@@ -110,18 +110,20 @@ module.exports = function(app) {
   };
 
   const getBalance = (id, cb) => {
-    sequelize.query(`
-      select
-        CAST(SUM("netAmountInGroupCurrency") AS FLOAT)/100 AS total
-        FROM "Transactions"
-        WHERE "GroupId"=${id} AND approved = true`,
-    {
-      type: sequelize.QueryTypes.SELECT
-    })
-    .then((result) => {
-      return cb(null, result[0].total)
-    })
-    .catch(cb);
+    Transaction
+      .find({
+        attributes: [
+          [sequelize.fn('SUM', sequelize.col('netAmountInGroupCurrency')), 'total']
+        ],
+        where: {
+          GroupId: id,
+            approved: true
+          }
+        })
+        .then((result) => {
+          return cb(null, result.toJSON().total/100);
+        })
+        .catch(cb);
   };
 
   const getPublicPageInfo = (id, cb) => {

--- a/app/controllers/groups.js
+++ b/app/controllers/groups.js
@@ -110,18 +110,18 @@ module.exports = function(app) {
   };
 
   const getBalance = (id, cb) => {
-    Transaction
-      .find({
-        attributes: [
-          [sequelize.fn('SUM', sequelize.col('amount')), 'total']
-        ],
-        where: {
-          GroupId: id,
-          approved: true
-        }
-      })
-      .then((result) => cb(null, result.toJSON().total))
-      .catch(cb);
+    sequelize.query(`
+      select
+        CAST(SUM("netAmountInGroupCurrency") AS FLOAT)/100 AS total
+        FROM "Transactions"
+        WHERE "GroupId"=${id} AND approved = true`,
+    {
+      type: sequelize.QueryTypes.SELECT
+    })
+    .then((result) => {
+      return cb(null, result[0].total)
+    })
+    .catch(cb);
   };
 
   const getPublicPageInfo = (id, cb) => {

--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -35,6 +35,19 @@ module.exports = function(app) {
     var group = args.group || {};
     var paymentMethod = args.paymentMethod || {};
 
+    if (transaction.amount > 0 && transaction.txnCurrencyFxRate) {
+      // populate netAmountInGroupCurrency for donations
+        transaction.netAmountInGroupCurrency =
+          Math.round((transaction.amountInTxnCurrency
+            - transaction.platformFeeInTxnCurrency
+            - transaction.hostFeeInTxnCurrency
+            - transaction.paymentProcessorFeeInTxnCurrency)
+          *transaction.txnCurrencyFxRate);
+    } else {
+      // populate netAmountInGroupCurrency for "Add Funds" and Expenses
+      transaction.netAmountInGroupCurrency = transaction.amount*100;
+    }
+
     async.auto({
 
       createTransaction: (cb) => {

--- a/app/models/Transaction.js
+++ b/app/models/Transaction.js
@@ -154,7 +154,7 @@ module.exports = function(Sequelize, DataTypes) {
           interval: this.interval,
           platformFee: this.platformFee,
           hostFee: this.hostFee,
-          paymentProcessingFee: this.paymentProcessingFee,
+          paymentProcessorFee: this.paymentProcessorFee,
           netAmountInGroupCurrency: this.netAmountInGroupCurrency
         };
       }

--- a/app/models/Transaction.js
+++ b/app/models/Transaction.js
@@ -58,7 +58,8 @@ module.exports = function(Sequelize, DataTypes) {
     platformFeeInTxnCurrency: DataTypes.INTEGER,
     hostFeeInTxnCurrency: DataTypes.INTEGER,
     paymentProcessorFeeInTxnCurrency: DataTypes.INTEGER,
-    stripeSubscriptionId: DataTypes.STRING, // // delete #postmigration
+    netAmountInGroupCurrency: DataTypes.INTEGER, // stores the net amount received by the group
+    stripeSubscriptionId: DataTypes.STRING, // delete #postmigration
 
     interval: {
       type: DataTypes.STRING
@@ -153,7 +154,8 @@ module.exports = function(Sequelize, DataTypes) {
           interval: this.interval,
           platformFee: this.platformFee,
           hostFee: this.hostFee,
-          paymentProcessingFee: this.paymentProcessingFee
+          paymentProcessingFee: this.paymentProcessingFee,
+          netAmountInGroupCurrency: this.netAmountInGroupCurrency
         };
       }
     }

--- a/migrations/20160415194252-add-netAmountInGroupCurrency-to-Transactions-migration.js
+++ b/migrations/20160415194252-add-netAmountInGroupCurrency-to-Transactions-migration.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('Transactions', 'netAmountInGroupCurrency', { type: Sequelize.INTEGER });
+
+  },
+
+  down: function (queryInterface) {
+    return queryInterface.removeColumn('Transactions', 'netAmountInGroupCurrency');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "db:migrate:undo": "sequelize db:migrate:undo --config config/sequelize_cli.json --models-path app/models/ --env  $SEQUELIZE_ENV",
     "db:migrate:dev": "sequelize db:migrate --models-path app/models/ --env development --url postgres://localhost:5432/${PG_DATABASE:='opencollective_localhost'}",
     "db:seed": "sequelize db:seed --config config/sequelize_cli.json --env  $SEQUELIZE_ENV",
-    "db:copy:prod": "./scripts/db_copy_to_localhost.sh prod && npm run db:sanitize",
+    "db:copy:prod": "./scripts/db_copy_to_localhost.sh prod && PG_DATABASE=opencollective_prod_snapshot npm run db:sanitize",
     "db:copy:staging": "./scripts/db_copy_to_localhost.sh staging",
     "db:copy:prod:staging": "./scripts/db_copy_prod_to_staging.sh && heroku run npm run db:sanitize --app opencollective-staging-api",
     "db:sanitize": "node scripts/replace_stripe_accounts",

--- a/scripts/populate_netamountingroupcurrency_in_transactions.js
+++ b/scripts/populate_netamountingroupcurrency_in_transactions.js
@@ -1,0 +1,30 @@
+const app = require('../index');
+const models = app.set('models');
+
+const done = (err) => {
+  if (err) console.log('err', err);
+  console.log('done!');
+  process.exit();
+};
+
+// Get all transactions
+models.Transaction.findAll({})
+.map(transaction => {
+  console.log("Processing transaction id: ", transaction.id);
+
+    if (transaction.amount > 0 && transaction.txnCurrencyFxRate) {
+      // populate netAmountInGroupCurrency for donations
+        transaction.netAmountInGroupCurrency =
+          Math.round((transaction.amountInTxnCurrency -
+            transaction.platformFeeInTxnCurrency -
+            transaction.hostFeeInTxnCurrency -
+            transaction.paymentProcessorFeeInTxnCurrency) *
+          transaction.txnCurrencyFxRate);
+    } else {
+      // populate netAmountInGroupCurrency for "Add Funds" and Expenses
+      transaction.netAmountInGroupCurrency = transaction.amount*100;
+    }
+  return transaction.save();
+})
+.then(() => done())
+.catch(done)

--- a/test/donations.routes.test.js
+++ b/test/donations.routes.test.js
@@ -283,6 +283,7 @@ describe('donations.routes.test.js', () => {
             expect(res.rows[0]).to.have.property('platformFeeInTxnCurrency', 70);
             expect(res.rows[0]).to.have.property('paymentProcessorFeeInTxnCurrency', 155);
             expect(res.rows[0]).to.have.property('txnCurrencyFxRate', 0.785);
+            expect(res.rows[0]).to.have.property('netAmountInGroupCurrency', 867)
             expect(res.rows[0]).to.have.property('paidby', user.id.toString());
             expect(res.rows[0]).to.have.property('approved', true);
             expect(res.rows[0].tags[0]).to.be.equal('Donation');

--- a/test/webhooks.routes.test.js
+++ b/test/webhooks.routes.test.js
@@ -291,6 +291,7 @@ describe('webhooks.routes.test.js', () => {
           expect(res.rows[0]).to.have.property('platformFeeInTxnCurrency', 70);
           expect(res.rows[0]).to.have.property('paymentProcessorFeeInTxnCurrency', 155);
           expect(res.rows[0]).to.have.property('txnCurrencyFxRate', 0.25);
+          expect(res.rows[0]).to.have.property('netAmountInGroupCurrency', 276)
           expect(transaction.amount).to.be.equal(webhookSubscription.amount / 100);
           expect(transaction.Subscription.stripeSubscriptionId).to.be.equal(webhookSubscription.id);
           expect(transaction.Subscription.isActive).to.be.equal(true);
@@ -363,6 +364,7 @@ describe('webhooks.routes.test.js', () => {
               expect(res.rows[0]).to.have.property('platformFeeInTxnCurrency', 70);
               expect(res.rows[0]).to.have.property('paymentProcessorFeeInTxnCurrency', 155);
               expect(res.rows[0]).to.have.property('txnCurrencyFxRate', 0.25);
+              expect(res.rows[0]).to.have.property('netAmountInGroupCurrency', 276);
               expect(transaction.Subscription.stripeSubscriptionId).to.be.equal(webhookSubscription.id);
               expect(transaction.Subscription.isActive).to.be.equal(true);
               expect(transaction.Subscription).to.have.property('activatedAt');


### PR DESCRIPTION
- Creates a new field called `netAmountInGroupCurrency` in `Transactions`
- Runs migration for it
- Populates that field on every new `Transaction`
- Includes a script that needs to be run in staging and production

Note: if you try this right now, it'll be inaccurate in staging and production. We'll need to manually delete the rows for fees that we added for Feb.