### PR TITLE
Might not be needed to explicitly rebuild bcrypt …

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Rebuild for bcrypt on circleci and other envs
-npm rebuild
+
+set -e
 
 # Only run migrations automatically on staging and production
 if [ "$SEQUELIZE_ENV" = "staging" ] || [ "$SEQUELIZE_ENV" = "production" ]; then


### PR DESCRIPTION
…as APT c++ build packages are already installed prior to npm install