### PR TITLE
Don't filter on userId for counting webhook stripe received activities...

### DIFF
--- a/scripts/report_transactions.js
+++ b/scripts/report_transactions.js
@@ -63,7 +63,7 @@ async.auto({
   stripeReceivedCount: cb => {
     const stripeReceived = { where: { type: activities.WEBHOOK_STRIPE_RECEIVED } };
     models.Activity
-        .count(_.merge({}, createdLastWeek, stripeReceived, excludeOcTeam))
+        .count(_.merge({}, createdLastWeek, stripeReceived))
         .done(cb);
   },
 


### PR DESCRIPTION
... because their `UserId` is `null` anyway