### PR TITLE
Making sure we return an Integer as error code

### DIFF
--- a/server/middleware/error_handler.js
+++ b/server/middleware/error_handler.js
@@ -44,7 +44,7 @@ module.exports = (err, req, res, next) => {
     err = new errors.ValidationFailed(null, _.map(err.errors, (e) => e.path), 'Unique Constraint Error.');
   }
 
-  if (!err.code) {
+  if (!err.code || !Number.isInteger(err.code)) {
     var code = (err.type && err.type.indexOf('Stripe') > -1) ? 400 : 500;
     err.code = err.status || code;
   }


### PR DESCRIPTION
Fix for https://papertrailapp.com/groups/1997763/events?q=%22Error%22+OR+%22code%3A+500%22+OR+%22Error+Express%22&q_id=7200403

```
Error Express :  { [Error: Your card was declined.]
  code: 'card_declined',
  type: 'StripeCardError',
  message: 'Your card was declined.' }
_http_server.js:192
    throw new RangeError(`Invalid status code: ${statusCode}`);
    ^

RangeError: Invalid status code: 0
    at ServerResponse.writeHead (_http_server.js:192:11)
```

This doesn't solve the reason why the card is declined but at least by fixing this we will be able to get a proper error email with the curl command to reproduce it.